### PR TITLE
Use alt+s instead of ctrl+s

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,6 +1,6 @@
 # default key sequence: Ctrl+s
 set -q sudope_sequence
-  or set -l sudope_sequence \cs
+  or set -l sudope_sequence \es
 
 # if sudope is already bound to some sequence, leave it
 if not bind | string match -rq '[[:space:]]sudope$'


### PR DESCRIPTION
Because in fish 3.0, ctrl+s is taken